### PR TITLE
Add 'extern "C"' to function declaration to allow linking with C++ code

### DIFF
--- a/inc/drivers.h
+++ b/inc/drivers.h
@@ -4,6 +4,7 @@
 #include "hal.h"
 #include "drivers_conf.h"
 #include "dac_driver.h"
+#include "eeprom_driver.h"
 #include "iwdg_driver.h"
 #include "timcap_driver.h"
 #include "iuart_driver.h"


### PR DESCRIPTION
To use the drivers with C++ code (especially the drivers.h header), the function prototypes have to be presented with extern "C" statement to the compiler.
