### PR TITLE
Update way of validating IRQ priority

### DIFF
--- a/stm32/eicu_driver_lld.h
+++ b/stm32/eicu_driver_lld.h
@@ -210,42 +210,42 @@
 #endif
 
 #if STM32_EICU_USE_TIM1 &&                                                   \
-    !CORTEX_IS_VALID_KERNEL_PRIORITY(STM32_EICU_TIM1_IRQ_PRIORITY)
+    !CH_IRQ_IS_VALID_KERNEL_PRIORITY(STM32_EICU_TIM1_IRQ_PRIORITY)
 #error "Invalid IRQ priority assigned to TIM1"
 #endif
 
 #if STM32_EICU_USE_TIM2 &&                                                   \
-    !CORTEX_IS_VALID_KERNEL_PRIORITY(STM32_EICU_TIM2_IRQ_PRIORITY)
+    !CH_IRQ_IS_VALID_KERNEL_PRIORITY(STM32_EICU_TIM2_IRQ_PRIORITY)
 #error "Invalid IRQ priority assigned to TIM2"
 #endif
 
 #if STM32_EICU_USE_TIM3 &&                                                   \
-    !CORTEX_IS_VALID_KERNEL_PRIORITY(STM32_EICU_TIM3_IRQ_PRIORITY)
+    !CH_IRQ_IS_VALID_KERNEL_PRIORITY(STM32_EICU_TIM3_IRQ_PRIORITY)
 #error "Invalid IRQ priority assigned to TIM3"
 #endif
 
 #if STM32_EICU_USE_TIM4 &&                                                   \
-    !CORTEX_IS_VALID_KERNEL_PRIORITY(STM32_EICU_TIM4_IRQ_PRIORITY)
+    !CH_IRQ_IS_VALID_KERNEL_PRIORITY(STM32_EICU_TIM4_IRQ_PRIORITY)
 #error "Invalid IRQ priority assigned to TIM4"
 #endif
 
 #if STM32_EICU_USE_TIM5 &&                                                   \
-    !CORTEX_IS_VALID_KERNEL_PRIORITY(STM32_EICU_TIM5_IRQ_PRIORITY)
+    !CH_IRQ_IS_VALID_KERNEL_PRIORITY(STM32_EICU_TIM5_IRQ_PRIORITY)
 #error "Invalid IRQ priority assigned to TIM5"
 #endif
 
 #if STM32_EICU_USE_TIM8 &&                                                   \
-    !CORTEX_IS_VALID_KERNEL_PRIORITY(STM32_EICU_TIM8_IRQ_PRIORITY)
+    !CH_IRQ_IS_VALID_KERNEL_PRIORITY(STM32_EICU_TIM8_IRQ_PRIORITY)
 #error "Invalid IRQ priority assigned to TIM8"
 #endif
 
 #if STM32_EICU_USE_TIM9 &&                                                   \
-    !CORTEX_IS_VALID_KERNEL_PRIORITY(STM32_EICU_TIM9_IRQ_PRIORITY)
+    !CH_IRQ_IS_VALID_KERNEL_PRIORITY(STM32_EICU_TIM9_IRQ_PRIORITY)
 #error "Invalid IRQ priority assigned to TIM9"
 #endif
 
 #if STM32_EICU_USE_TIM12 &&                                                  \
-    !CORTEX_IS_VALID_KERNEL_PRIORITY(STM32_EICU_TIM12_IRQ_PRIORITY)
+    !CH_IRQ_IS_VALID_KERNEL_PRIORITY(STM32_EICU_TIM12_IRQ_PRIORITY)
 #error "Invalid IRQ priority assigned to TIM12"
 #endif
 


### PR DESCRIPTION
Macro CORTEX_IS_VALID_KERNEL_PRIORITY is no longer available. I believe CH_IRQ_IS_VALID_KERNEL_PRIORITY should be called instead.